### PR TITLE
Texture antialiasing vs. aliasing was reversed

### DIFF
--- a/cocos2d/textures/CCTexture2D.cs
+++ b/cocos2d/textures/CCTexture2D.cs
@@ -165,14 +165,14 @@ namespace Cocos2D
                     {
 						m_samplerState = new SamplerState
 						{
-							Filter = TextureFilter.Point
+							Filter = TextureFilter.Linear
 						};
                     }
                     else
                     {
 						m_samplerState = new SamplerState
 						{
-							Filter = TextureFilter.Linear
+							Filter = TextureFilter.Point
 						};
                     }
 

--- a/cocos2d/textures/CCTexture2D.cs
+++ b/cocos2d/textures/CCTexture2D.cs
@@ -165,27 +165,21 @@ namespace Cocos2D
                     {
 						m_samplerState = new SamplerState
 						{
-							Filter = TextureFilter.Point,
-							AddressU = saveState.AddressU,
-							AddressV = saveState.AddressV,
-							AddressW = saveState.AddressW
+							Filter = TextureFilter.Point
 						};
-
                     }
                     else
                     {
 						m_samplerState = new SamplerState
 						{
-							Filter = TextureFilter.Linear,
-							AddressU = saveState.AddressU,
-							AddressV = saveState.AddressV,
-							AddressW = saveState.AddressW
+							Filter = TextureFilter.Linear
 						};
-
                     }
 
+                    m_samplerState.AddressU = saveState.AddressU;
+                    m_samplerState.AddressV = saveState.AddressV;
+                    m_samplerState.AddressW = saveState.AddressW;
                 }
-
             }
         }
 


### PR DESCRIPTION
Two changes:
1. Antialiasing means a texture is blurry (but zoomable) with LINEAR filtering. Aliasing means a texture is sharp and pixelated (but zooming brings in artifacts) with POINT filtering.
2. Moved shared `m_samplerState.AddressU/V/W` out of the if branches.
